### PR TITLE
General error: 1 too many SQL variables

### DIFF
--- a/src/Sushi.php
+++ b/src/Sushi.php
@@ -126,8 +126,14 @@ trait Sushi
                 $table->timestamps();
             }
         });
+        
+        $rows = collect($rows);
 
-        static::insert($rows);
+        $chunks = $rows->chunk(500);
+
+        foreach ($chunks as $chunk) {
+            static::insert($chunk->toArray());
+        }
     }
 
     public function usesTimestamps()


### PR DESCRIPTION
Resolves too many SQL variables limitation by chunking big array sets.